### PR TITLE
'license' property added to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/alexandrudima/vscode-lcov"
   },
+  "license": "The MIT License (MIT)",
   "engines": {
     "vscode": "^1.15.0"
   },


### PR DESCRIPTION
'npm' gives a warning regarding the lacking of 'license' property in the package.