### PR TITLE
more package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "vscode-lcov",
       "version": "0.3.0",
+      "license": "MIT",
       "dependencies": {
         "elegant-spinner": "^3.0.0",
         "lcov-parse": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,21 @@
   "name": "vscode-lcov",
   "displayName": "VSCode LCOV",
   "description": "Renders line and branch test coverage",
+  "license": "MIT",
+  "author": {
+      "name": "Alex Dima",
+      "email": "alexdima@microsoft.com"
+  },
   "version": "0.3.0",
   "publisher": "alexdima",
   "repository": {
     "type": "git",
     "url": "https://github.com/alexandrudima/vscode-lcov"
   },
+  "bugs": {
+    "url": "https://github.com/alexandrudima/vscode-lcov/issues"
+  },
+  "homepage": "https://github.com/alexandrudima/vscode-lcov",
   "engines": {
     "vscode": "^1.34.0"
   },


### PR DESCRIPTION
also fixing npm warning about missing license identifier #28 (but other than that, follow [the npm spec](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license) and use the SPDX identifier instead of the clearname)